### PR TITLE
Fix pw history back

### DIFF
--- a/src/atom/chat.ts
+++ b/src/atom/chat.ts
@@ -56,6 +56,7 @@ export const currentChatInfoState = atom<ChatRoomInfoDTO>({
     mutedUsers: [],
     bannedUsers: [],
     joinedUser: [],
+    curPassword: '',
   },
 });
 

--- a/src/component/Chat/Chat.tsx
+++ b/src/component/Chat/Chat.tsx
@@ -1,10 +1,15 @@
 import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { ChatSection } from './ChatSection';
 import { UserSection } from './User/UserSection';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  useRecoilState,
+  useRecoilValue,
+  useResetRecoilState,
+  useSetRecoilState,
+} from 'recoil';
 import { NotificationModal } from '../Header/NotificationModal';
 import { ProfileModal } from '../Header/ProfileModal';
-import { currentChatInfoState, roleState } from '../../atom/chat';
+import { currentChatInfoState } from '../../atom/chat';
 import { userInfo } from '../../atom/user';
 import { ChatSocket } from '../../sockets/ChatSocket';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -28,38 +33,25 @@ export const Chat = () => {
 
   const user = useRecoilValue(userInfo);
   const [roomInfo, setRoomInfo] = useRecoilState(currentChatInfoState);
+  const resetRoomInfo = useResetRecoilState(currentChatInfoState);
   const setPassword = useSetRecoilState(passwordModalState);
   const params = useParams();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const role = useSetRole();
 
-  useLayoutEffect(() => {
-    if (params.id === undefined || params.levelOfPublicity === undefined) {
-      alert('잘못된 접근입니다.');
-      navigate('/');
-    }
-    if (params.levelOfPublicity === 'Pub') {
-      ChatSocket.emit('join-room', requestJoinChatRoom);
-    } else if (params.levelOfPublicity === 'Prot') {
-      setPassword(true);
-    }
-    ChatSocket.on('join-room', handleJoinChatRoom);
-    ChatSocket.on('error', handleError);
-
-    return () => {
-      ChatSocket.off('join-room', handleJoinChatRoom);
-      ChatSocket.off('error', handleError);
+  const requestJoinChatRoom = (password?: string): JoinGroupChatDTO => {
+    const baseObject: JoinGroupChatDTO = {
+      groupChatId: Number(params.id),
+      userId: user.id,
     };
-  }, [user]);
 
-  const requestJoinChatRoom: JoinGroupChatDTO = {
-    groupChatId: parseInt(params.id as string, 10),
-    userId: user.id,
+    if (password) return { ...baseObject, password };
+
+    return baseObject;
   };
 
   const handleError = (data: any) => {
-    console.log(data);
     if (data === 'Request failed with status code 403') {
       alert('채팅방에 입장할 수 없습니다.');
       navigate('/');
@@ -70,6 +62,42 @@ export const Chat = () => {
     setRoomInfo(data);
     setLoading(false);
   };
+
+  useLayoutEffect(() => {
+    if (params.id === undefined || params.levelOfPublicity === undefined) {
+      alert('잘못된 접근입니다.');
+      navigate('/');
+    }
+
+    ChatSocket.on('join-room', handleJoinChatRoom);
+    ChatSocket.on('error', handleError);
+
+    switch (params.levelOfPublicity) {
+      case 'Pub':
+        ChatSocket.emit('join-room', requestJoinChatRoom());
+        break;
+      case 'Prot': {
+        if (
+          roomInfo.groupChatId === Number(params.id) &&
+          role !== 'user ' &&
+          roomInfo.curPassword
+        ) {
+          setRoomInfo({ ...roomInfo, curPassword: '' });
+          ChatSocket.emit(
+            'join-room',
+            requestJoinChatRoom(roomInfo.curPassword)
+          );
+        } else setPassword(true);
+        break;
+      }
+    }
+
+    return () => {
+      ChatSocket.off('join-room', handleJoinChatRoom);
+      ChatSocket.off('error', handleError);
+      resetRoomInfo();
+    };
+  }, [user]);
 
   if (isPasswordModalOpen) {
     return <PasswordModal groupChatId={params.id as string} />;

--- a/src/component/Chat/Manage/PassWordChangeModal.tsx
+++ b/src/component/Chat/Manage/PassWordChangeModal.tsx
@@ -4,10 +4,11 @@ interface props {
   setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setPassWord: React.Dispatch<React.SetStateAction<string>>;
   changePassword: () => void;
+  levelOfPublicity: string;
 }
 
 export const PassWordChangeModal = (props: props) => {
-  const { setModalOpen, setPassWord, changePassword } = props;
+  const { setModalOpen, setPassWord, changePassword, levelOfPublicity } = props;
   const closeModal = () => {
     setModalOpen(false);
   };
@@ -15,6 +16,21 @@ export const PassWordChangeModal = (props: props) => {
   const handlePassWordInput = (e: any) => {
     setPassWord(e.target.value);
   };
+
+  const textArray = [
+    {
+      title: '비밀번호 추가',
+      placeholder: '새로운 비밀번호를 입력해주세요.',
+      button: '추가',
+    },
+    {
+      title: '비밀번호 변경',
+      placeholder: '변경할 비밀번호를 입력해주세요.',
+      button: '변경',
+    },
+  ];
+
+  const text = levelOfPublicity === 'Pub' ? textArray[0] : textArray[1];
 
   return (
     <div
@@ -26,11 +42,11 @@ export const PassWordChangeModal = (props: props) => {
         onClick={(e) => e.stopPropagation()}
       >
         <span className="flex text-gray-400 text-lg mb-6 font-semibold">
-          비밀번호 변경
+          {text.title}
         </span>
         <input
           type="text"
-          placeholder="변경할 비밀번호를 입력해주세요."
+          placeholder={text.placeholder}
           onChange={handlePassWordInput}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
@@ -43,7 +59,7 @@ export const PassWordChangeModal = (props: props) => {
           onClick={changePassword}
           className="w-16 h-8 bg-progressBlue rounded-full text-white mt-6"
         >
-          변경
+          {text.button}
         </button>
       </div>
     </div>

--- a/src/component/Chat/Manage/RoomInfo.tsx
+++ b/src/component/Chat/Manage/RoomInfo.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ChatRoomInfoDTO } from '../../../interfaces/Chatting-Format.dto';
 import { ChatList } from '../ChatList/ChatList';
 import useChatRoomPwManage from '../../../hooks/chat/useChatRoomPwManage';
@@ -29,7 +28,11 @@ export const RoomInfo = (props: props) => {
           props.roomInfo.levelOfPublicity !== 'Priv' && (
             <PassWordButton
               onClickFunc={() => setPassWordModal(true)}
-              text="비밀번호 변경"
+              text={
+                props.roomInfo.levelOfPublicity === 'Pub'
+                  ? '비밀번호 추가'
+                  : '비밀번호 변경'
+              }
             />
           )}
         {props.role === 'owner' &&
@@ -45,6 +48,7 @@ export const RoomInfo = (props: props) => {
           setModalOpen={setPassWordModal}
           setPassWord={setPassWord}
           changePassword={changePassword}
+          levelOfPublicity={props.roomInfo.levelOfPublicity}
         />
       )}
     </section>

--- a/src/hooks/chat/useChatRoomPwManage.ts
+++ b/src/hooks/chat/useChatRoomPwManage.ts
@@ -24,15 +24,20 @@ export default function useChatRoomPwManage() {
       updateRoomInfo
     );
 
-    if (res.status === 200) {
+    if (res.status === 200 || res.status === 201) {
       setPassWord('');
       setPassWordModal(false);
-      setRoomInfo({ ...roomInfo, curPassword: passWord });
-      if (roomInfo.levelOfPublicity === 'Pub')
-        setRoomInfo({
-          ...roomInfo,
-          levelOfPublicity: 'Prot',
-        });
+      setRoomInfo({
+        ...roomInfo,
+        curPassword: passWord,
+        levelOfPublicity: 'Prot',
+      });
+      //console.log('비밀번호 추가 완');
+      //if (roomInfo.levelOfPublicity === 'Pub')
+      //  setRoomInfo({
+      //    ...roomInfo,
+      //    levelOfPublicity: 'Prot',
+      //  });
       alert('비밀번호가 변경되었습니다.');
     }
   };
@@ -47,7 +52,7 @@ export default function useChatRoomPwManage() {
       updateRoomInfo
     );
 
-    if (res.status === 200) {
+    if (res.status === 200 || res.status === 201) {
       setPassWord('');
       setPassWordModal(false);
       if (roomInfo.levelOfPublicity === 'Prot')

--- a/src/hooks/chat/useChatRoomPwManage.ts
+++ b/src/hooks/chat/useChatRoomPwManage.ts
@@ -27,8 +27,12 @@ export default function useChatRoomPwManage() {
     if (res.status === 200) {
       setPassWord('');
       setPassWordModal(false);
+      setRoomInfo({ ...roomInfo, curPassword: passWord });
       if (roomInfo.levelOfPublicity === 'Pub')
-        setRoomInfo({ ...roomInfo, levelOfPublicity: 'Prot' });
+        setRoomInfo({
+          ...roomInfo,
+          levelOfPublicity: 'Prot',
+        });
       alert('비밀번호가 변경되었습니다.');
     }
   };

--- a/src/interfaces/Chatting-Format.dto.ts
+++ b/src/interfaces/Chatting-Format.dto.ts
@@ -25,6 +25,7 @@ export interface ChatRoomInfoDTO {
   mutedUsers: MutedUserDto[];
   bannedUsers: senderDTO[];
   joinedUser: senderDTO[];
+  curPassword?: string;
 }
 
 export interface MutedUserDto {


### PR DESCRIPTION
<br/>

## 이슈 처리

-  ### private 인 방 설정 창에서 뒤로가기 누르면 비밀번호 입력 창이 뜹니다 (그치만 전 괜찮다고 생각 ... 문단속 같은 느낌으로 ㅎ)
   -  protected-> protected (비밀번호 변경) 은 재검증 안하게 했어요
   -  protected -> public (비밀번호 삭제)
   -  public -> protected (비밀번호 추가)
   -  위 두개는  뒤로가기 버튼 누르면 에러 얼러트창 떠요
       history uri 권한이랑 지금 방 정보 권한이 일치하지 않아서 .. 지금은 어쩔 수 없는듯합니다..
<br/>

- ### 방 정보 컴포넌트? 통통한 거 누르면 방으로 들어가져요 (전 괜찮다고 생각했는데 빼실 생각 있으신 것 같아서 적어뒀어염)
     -   그래서  얘를 그냥 살렸습니다.. 변경하고 얘 누르면 방 공개 권한 변경 상관없이 들어갈 수 있어요
<br/>

- ### 프로텍트 방 안 만들어져요 🥹
    - 얘는.. @koreanddinghwan 백엔드 enum에 없더라고요..
   
<br/>
<br/>

## 추가

public -> protected일 때 관련 버튼들 "비밀번호 변경" -> "비밀번호 추가" 로 변경했어요
<br/>

확인 해주시고 이상하면..말씀해주세요
