### PR TITLE
fix: socket connect 의존성 user.id로 수정

### DIFF
--- a/src/component/Header/Profile.tsx
+++ b/src/component/Header/Profile.tsx
@@ -51,7 +51,7 @@ const Profile = () => {
         GameSocket.disconnect();
       };
     }
-  }, [isLoggedIn]);
+  }, [isLoggedIn, userInfoObj.id]);
 
   useEffect(() => {
     if (

--- a/src/hooks/user/useFetchUserMe.ts
+++ b/src/hooks/user/useFetchUserMe.ts
@@ -9,18 +9,19 @@ export default function useFetchUserMe() {
   const token = localStorage.getItem('token');
   const [login, setLogin] = useRecoilState(loginState);
 
+  const fetchUser = async () => {
+    const res = await axiosInstance.get<UserDto>('/user/me');
+    console.log(res.data);
+
+    setLogin(true);
+    setUser(res.data);
+  };
+
   useEffect(() => {
     if (token) {
       fetchUser();
     }
   }, [token]);
-
-  const fetchUser = async () => {
-    const res = await axiosInstance.get<UserDto>('user/me');
-
-    setLogin(true);
-    setUser(res.data);
-  };
 
   return login;
 }


### PR DESCRIPTION
의존성 아예 빼버리니까 loginState만 감지해버리고 소켓 커넥트를 안하더라고요
id로 걸어두면 프로필 수정해도 소켓 재연결 안돼서 이렇게 수정했습니다..

내일 알람 안오신다는 거 확인해주면서 같이 확인 부탁드려여!!!